### PR TITLE
Add support for Ubuntu sidebar window grouping.

### DIFF
--- a/rabbitvcs/util/helper.py
+++ b/rabbitvcs/util/helper.py
@@ -647,7 +647,9 @@ def launch_ui_window(filename, args=[], block=False):
         executable = sys.executable
         if "PYTHON" in os.environ.keys():
             executable = os.environ["PYTHON"]
-        proc = subprocess.Popen([executable, path] + args, env=env)
+        # Give all subprocesses the name 'RabbitVCS' to give Ubuntu desktop files the possibility
+        # to group those windows in the launcher on WM_CLASS.
+        proc = subprocess.Popen([executable, path] + ['--name', 'RabbitVCS'] + args, env=env)
 
         if block:
             proc.wait()


### PR DESCRIPTION
A solution for https://github.com/rabbitvcs/rabbitvcs/issues/149 . Now, you can create this desktop file on Ubuntu:

```
[Desktop Entry]
Encoding=UTF-8
Name=RabbitVCS
Exec=rabbitvcs browser
Icon=rabbitvcs
Categories=Application;Development;
Type=Application
StartupNotify=true
StartupWMClass=RabbitVCS
Terminal=0
```

and have all RabbitVCS windows grouped below it.